### PR TITLE
[DM-5744] Create packer automation for ELK

### DIFF
--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -148,7 +148,9 @@
         "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
+        "scripts/centos/cloud-init.sh",
         "scripts/centos/cleanup.sh",
+        "scripts/centos/cleanup-cloud.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/scripts/centos/cleanup-cloud.sh
+++ b/scripts/centos/cleanup-cloud.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -eux
+
+rm -rf /etc/udev/rules.d/70-persistent-net.rules;
+
+# cleanup centos user account (if it exists)
+if id -u centos > /dev/null 2>&1; then
+    /usr/sbin/userdel -rf centos
+fi
+
+# cleanup any ssh keys nova/cloud-init may have injected
+rm -rf /root/.ssh
+find  /home/ -maxdepth 2 -type d -name .ssh -exec rm -rf {} \;
+
+# per https://aws.amazon.com/articles/0155828273219400
+find /root/.*history /home/*/.*history -print0 | xargs -0 rm -f || true
+find /home/*/.ssh -name "authorized_keys" -print0 | xargs -0 rm -f || true
+
+sed -i.bak \
+    -e 's/^#PermitRootLogin yes/PermitRootLogin yes/' \
+    -e 's/^#PermitEmptyPasswords yes/PermitEmptyPasswords no/' \
+    -e 's/PermitEmptyPasswords yes/PermitEmptyPasswords no/' \
+    -e 's/^#PasswordAuthentication yes/PasswordAuthentication no/' \
+    -e 's/PasswordAuthentication yes/PasswordAuthentication no/' \
+    -e 's/^#X11Forwarding yes/X11Forwarding no/' \
+    -e 's/X11Forwarding yes/X11Forwarding no/' \
+        /etc/ssh/sshd_config

--- a/scripts/centos/cloud-init.sh
+++ b/scripts/centos/cloud-init.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -eux
+
+yum -y install cloud-init

--- a/scripts/ubuntu/cleanup-cloud.sh
+++ b/scripts/ubuntu/cleanup-cloud.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -eux
+
+rm -rf /etc/udev/rules.d/70-persistent-net.rules;
+
+# cleanup ubuntu user account (if it exists)
+if id -u ubuntu > /dev/null 2>&1; then
+    /usr/sbin/userdel -rf ubuntu
+fi
+
+# cleanup any ssh keys nova/cloud-init may have injected
+rm -rf /root/.ssh
+find  /home/ -maxdepth 2 -type d -name .ssh -exec rm -rf {} \; || true
+
+# per https://aws.amazon.com/articles/0155828273219400
+find /root/.*history /home/*/.*history -print0 | xargs -0 rm -f || true
+find /home/*/.ssh -name "authorized_keys" -print0 | xargs -0 rm -f || true
+
+sed -i.bak \
+    -e 's/^#PermitRootLogin yes/PermitRootLogin yes/' \
+    -e 's/^#PermitEmptyPasswords yes/PermitEmptyPasswords no/' \
+    -e 's/PermitEmptyPasswords yes/PermitEmptyPasswords no/' \
+    -e 's/^#PasswordAuthentication yes/PasswordAuthentication no/' \
+    -e 's/PasswordAuthentication yes/PasswordAuthentication no/' \
+    -e 's/^#X11Forwarding yes/X11Forwarding no/' \
+    -e 's/X11Forwarding yes/X11Forwarding no/' \
+        /etc/ssh/sshd_config

--- a/scripts/ubuntu/cloud-init.sh
+++ b/scripts/ubuntu/cloud-init.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -eux
+
+apt-get -y install cloud-init cloud-initramfs-growroot

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -234,7 +234,9 @@
         "scripts/ubuntu/sudoers.sh",
         "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
+        "scripts/ubuntu/cloud-init.sh",
         "scripts/ubuntu/cleanup.sh",
+        "scripts/ubuntu/cleanup-cloud.sh",
         "scripts/common/minimize.sh"
       ],
       "type": "shell"

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
Add headless option to the qemu builders. Using scripts, install cloud-init and remove user artifacts.
- qemu builds for CentOS 7.2 x86_64 and Ubuntu 14.04 amd64 use `"{{ user `headless` }}"` variable.
- The Packer openstack builder requires cloud-init, so install
  it before pushing the QEMU QCOW2 image to the OpenStack Glance.
- Remove histories and ssh artifacts before imaging.
- Remove the distribution default users.
- There is possible duplication in cleaning up .ssh directories and authorized_keys in `cleanup-cloud.sh`. I errored on the side of keeping both.
  
  modified:   centos-7.2-x86_64.json
  new file:   scripts/centos/cleanup-cloud.sh
  new file:   scripts/centos/cloud-init.sh
  new file:   scripts/ubuntu/cleanup-cloud.sh
  new file:   scripts/ubuntu/cloud-init.sh
  modified:   ubuntu-14.04-amd64.json
